### PR TITLE
Deb packaging

### DIFF
--- a/digitalscratch/dist/debian/debian/changelog
+++ b/digitalscratch/dist/debian/debian/changelog
@@ -12,7 +12,7 @@ digitalscratch (1.7.0-1) stable; urgency=medium
   * tests:
      - travis CI: switch test environment from Ubuntu 12.04 to 14.04
   * libdigitalscratch (motion detection engine):
-     - bump to version 1.7.0 
+     - bump to version 1.7.0
 
  -- Julien Rosener <julien.rosener@digital-scratch.org>  Sat, 01 Dec 2018 01:17:24 +0100
 
@@ -47,7 +47,7 @@ digitalscratch (1.6.0-1) stable; urgency=medium
      - refactor logging system
      - refactor duplicate slots using lambda functions
   * motion detection engine (libdigitalscratch):
-     - rewrite the timecoded signal detection using FIR and IIR filters  
+     - rewrite the timecoded signal detection using FIR and IIR filters
 
  -- Julien Rosener <julien.rosener@digital-scratch.org>  Thu, 21 May 2015 00:59:08 +0200
 
@@ -88,7 +88,7 @@ digitalscratch (1.4.0-1) stable; urgency=low
      - added a progress bar when analysing file audio collection
   * build:
      - created Debian stable package
-     - added support of Qt4.x 
+     - added support of Qt4.x
 
  -- Julien Rosener <julien.rosener@digital-scratch.org>  Mon, 23 Dec 2013 00:36:33 +0100
 
@@ -109,7 +109,7 @@ digitalscratch (1.3.0-1) stable; urgency=low
   * bugs:
      - fixed error when reading audio file containing unicode chars
   * build:
-     - ported to Qt5 
+     - ported to Qt5
 
  -- Julien Rosener <julien.rosener@digital-scratch.org>  Tue, 30 Jul 2013 08:43:28 +0200
 
@@ -128,7 +128,7 @@ digitalscratch (1.2.0-1) stable; urgency=low
      - fixed icon issue in Ubuntu Unity
      - fixed a playback issue when playing backward after end of a track
   * build:
-     - ported to Windows 
+     - ported to Windows
 
  -- Julien Rosener <julien.rosener@digital-scratch.org>  Fri, 22 Feb 2013 00:25:40 +0100
 
@@ -148,7 +148,7 @@ digitalscratch (1.1.0-1) stable; urgency=low
      - moving mouse over a playback area highlight it
      - switched application icon from png to svg
   * license:
-     - switched from GPL V2 to GPL V3 
+     - switched from GPL V2 to GPL V3
 
  -- Julien Rosener <julien.rosener@digital-scratch.org>  Thu, 13 Dec 2012 18:42:32 +0100
 
@@ -162,6 +162,5 @@ digitalscratch (1.0.0-1) stable; urgency=low
      - work with 1 or 2 turntables
      - jack integration
      - support Serato Scratch Live CV02 vinyl disc
-
 
  -- Julien Rosener <julien.rosener@digital-scratch.org>  Thu, 12 May 2011 17:16:25 +0200

--- a/digitalscratch/dist/debian/debian/copyright
+++ b/digitalscratch/dist/debian/debian/copyright
@@ -9,7 +9,7 @@ License: GPL-3+
 
 Files: debian/*
 Copyright:
- 2018 Olivier Humbert <trebmuh@tuxfamily.org>
+ 2018-2019 Olivier Humbert <trebmuh@tuxfamily.org>
  2012-2018 Julien Rosener <julien.rosener@digital-scratch.org>
 License: GPL-3+
 
@@ -25,7 +25,7 @@ License: GPL-3+
  GNU General Public License for more details.
 Comment:
  You should have received a copy of the GNU General Public License
- along with this program. If not, see <http://www.gnu.org/licenses/>.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
  .
  On Debian systems, the complete text of the GNU General
  Public License version 3 can be found in "/usr/share/common-licenses/GPL-3".

--- a/digitalscratch/dist/debian/debian/rules
+++ b/digitalscratch/dist/debian/debian/rules
@@ -10,4 +10,4 @@
 #export DH_VERBOSE=1
 
 %:
-	dh $@ 
+	dh $@

--- a/libdigitalscratch/dist/debian/debian/changelog
+++ b/libdigitalscratch/dist/debian/debian/changelog
@@ -1,7 +1,7 @@
 libdigitalscratch (1.7.0-1) stable; urgency=medium
 
   * coding:
-     - rename some classes for better understanding  
+     - rename some classes for better understanding
 
  -- Julien Rosener <julien.rosener@digital-scratch.org>  Sat, 01 Dec 2018 00:53:38 +0100
 
@@ -12,13 +12,13 @@ libdigitalscratch (1.6.1-1) stable; urgency=medium
   * coding:
      - memory allocation
      - API dependency
-     - cppcheck suggestions  
+     - cppcheck suggestions
 
  -- Julien Rosener <julien.rosener@digital-scratch.org>  Wed, 08 Jun 2016 18:50:14 +0200
 
 libdigitalscratch (1.6.0-1) stable; urgency=medium
 
-  * rewrite the timecoded signal detection using FIR and IIR filters 
+  * rewrite the timecoded signal detection using FIR and IIR filters
   * refactor the API using more standard fonctions/handle
   * refactor the logging system
 
@@ -34,7 +34,7 @@ libdigitalscratch (1.5.0-1) stable; urgency=low
 libdigitalscratch (1.4.0-1) stable; urgency=low
 
   * added an amplification factor for the input timecoded signal
-  * support any sample rate 
+  * support any sample rate
 
  -- Julien Rosener <julien.rosener@digital-scratch.org>  Mon, 23 Dec 2013 00:26:30 +0100
 
@@ -46,7 +46,7 @@ libdigitalscratch (1.3.0-1) stable; urgency=low
 
 libdigitalscratch (1.2.0-1) stable; urgency=low
 
-  * ported to Windows 
+  * ported to Windows
 
  -- Julien Rosener <julien.rosener@digital-scratch.org>  Thu, 21 Feb 2013 20:35:45 +0100
 
@@ -54,7 +54,7 @@ libdigitalscratch (1.1.0-1) stable; urgency=low
 
   * added MixVibes and Final Scratch vinyl support (speed/direction only)
   * added API functions to get default configurations values
-  * source code license switched from GPL V2 to GPL V3 
+  * source code license switched from GPL V2 to GPL V3
 
  -- Julien Rosener <julien.rosener@digital-scratch.org>  Thu, 13 Dec 2012 18:07:02 +0100
 

--- a/libdigitalscratch/dist/debian/debian/copyright
+++ b/libdigitalscratch/dist/debian/debian/copyright
@@ -9,7 +9,7 @@ License: GPL-3+
 
 Files: debian/*
 Copyright:
- 2018 Olivier Humbert <trebmuh@tuxfamily.org>
+ 2018-2019 Olivier Humbert <trebmuh@tuxfamily.org>
  2012-2018 Julien Rosener <julien.rosener@digital-scratch.org>
 License: GPL-3+
 
@@ -25,7 +25,7 @@ License: GPL-3+
  GNU General Public License for more details.
 Comment:
  You should have received a copy of the GNU General Public License
- along with this program. If not, see <http://www.gnu.org/licenses/>.
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
  .
  On Debian systems, the complete text of the GNU General
  Public License version 3 can be found in "/usr/share/common-licenses/GPL-3".

--- a/libdigitalscratch/dist/debian/debian/rules
+++ b/libdigitalscratch/dist/debian/debian/rules
@@ -10,4 +10,4 @@
 #export DH_VERBOSE=1
 
 %:
-	dh $@ 
+	dh $@


### PR DESCRIPTION
Quelques améliorations de l'empaquetage Debian avec :
- http -> https
- suppression d'espaces inutiles
- passage à 2019

En espérant que ça aide.